### PR TITLE
Make inplace jacobian call have the correct output shape. Add test.

### DIFF
--- a/src/ode_def_opts.jl
+++ b/src/ode_def_opts.jl
@@ -294,7 +294,7 @@ function ode_def_opts(name::Symbol,opts::Dict{Symbol,Bool},ex::Expr,params...;M=
   if jac_exists
     overloadex = :(((p::$name))(::Type{Val{:jac}},t,u,J) = $Jex) |> esc
     push!(exprs,overloadex)
-    overloadex = :(((p::$name))(::Type{Val{:jac}},t::Number,u) = (J=similar(u); p(Val{:jac},t,u,J); J)) |> esc
+    overloadex = :(((p::$name))(::Type{Val{:jac}},t::Number,u) = (J=similar(u, (length(u), length(u))); p(Val{:jac},t,u,J); J)) |> esc
     push!(exprs,overloadex)
   end
   # Add the Exponential Jacobian

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,7 @@ f(Val{:jac},t,u,J)
 f(Val{:invjac},t,u,iJ)
 @test J  == [-1.5 -2.0
              3.0 -1.0]
+@test f(Val{:jac}, t, u) == [-1.5 -2.0; 3.0 -1.0]
 @test minimum(iJ - inv(J) .< 1e-10)
 
 println("Test Inv Rosenbrock-W")


### PR DESCRIPTION
Simple change to make the output be a matrix, and add a line to the jacobian test code to also test the non inplace version.