### PR TITLE
Mass matrix hotfix

### DIFF
--- a/src/maketype.jl
+++ b/src/maketype.jl
@@ -18,10 +18,12 @@ function maketype(name,param_dict,origex,funcs,syms,fex;
                   invjac_expr=:(),
                   invW_expr=:(),
                   invW_t_expr=:(),
-                  param_jac_expr=:())
+                  param_jac_expr=:(),
+                  mm_expr=:())
 
-    typeex = :(mutable struct $name{F,J,T,W,Wt,PJ,TT1,TT2} <: DiffEqBase.AbstractParameterizedFunction{true}
+    typeex = :(mutable struct $name{F,MM,J,T,W,Wt,PJ,TT1,TT2} <: DiffEqBase.AbstractParameterizedFunction{true}
         f::F
+        mass_matrix::MM
         analytic::Nothing
         jac::J
         tgrad::T
@@ -68,7 +70,7 @@ function maketype(name,param_dict,origex,funcs,syms,fex;
     param_Jex_ex = Meta.quot(param_Jex)
 
     constructorex = :($(name)() =
-                  $(name)($f_expr,nothing,
+                  $(name)($f_expr,$mm_expr,nothing,
                   $jac_expr,$tgrad_expr,$invW_expr,$invW_t_expr,$param_jac_expr,
                   $new_ex,$funcs,$pfuncs,$d_pfuncs,$syms,$symjac,$symtgrad,
                   $tgradex_ex,$Jex_ex,$expJex_ex,$param_Jex_ex,

--- a/src/ode_def_opts.jl
+++ b/src/ode_def_opts.jl
@@ -234,6 +234,9 @@ function ode_def_opts(name::Symbol,opts::Dict{Symbol,Bool},ex::Expr,params...;_M
   # Build the Function
   f_expr = :((internal_var___du,internal_var___u,internal_var___p,t::Number) -> $pex)
 
+  # Add the mass matrix
+  mm_expr = quote $M end
+
   # Add the t gradient
   if tgrad_exists
     tgrad_expr = :((internal_var___grad,internal_var___u,internal_var___p,t) -> $tgradex)
@@ -295,6 +298,7 @@ function ode_def_opts(name::Symbol,opts::Dict{Symbol,Bool},ex::Expr,params...;_M
                invW_expr=invW_expr,
                invW_t_expr=invW_t_expr,
                param_jac_expr=param_jac_expr,
+               mm_expr=mm_expr,
                symjac = convert.(Expr,symjac),
                symtgrad = convert.(Expr,symtgrad))
 


### PR DESCRIPTION
Add mass matrix field to the generated function types in support of https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/126.

I'm not familiar with metaprogramming so can anyone take a look to make sure this is correct?