### PR TITLE
Fix anonymous definition

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -8,7 +8,7 @@ macro ode_def(name,ex,params...)
     :build_hes => false,
     :build_invhes => false,
     :build_dpfuncs => true)
-    name isa Expr ? ode_def_opts(gensym(),opts,name,params...) :
+    name isa Expr ? ode_def_opts(gensym(),opts,name,ex,params...) :
         ode_def_opts(name,opts,ex,params...)
 end
 
@@ -22,7 +22,7 @@ macro ode_def_bare(name,ex,params...)
     :build_hes => false,
     :build_invhes => false,
     :build_dpfuncs => false)
-    name isa Expr ? ode_def_opts(gensym(),opts,name,params...) :
+    name isa Expr ? ode_def_opts(gensym(),opts,name,ex,params...) :
         ode_def_opts(name,opts,ex,params...)
 end
 
@@ -36,7 +36,7 @@ macro ode_def_nohes(name,ex,params...)
   :build_hes => false,
   :build_invhes => false,
   :build_dpfuncs => true)
-  name isa Expr ? ode_def_opts(gensym(),opts,name,params...) :
+  name isa Expr ? ode_def_opts(gensym(),opts,name,ex,params...) :
     ode_def_opts(name,opts,ex,params...)
 end
 
@@ -50,7 +50,7 @@ macro ode_def_noinvhes(name,ex,params...)
     :build_hes => false,
     :build_invhes => false,
     :build_dpfuncs => true)
-    name isa Expr ? ode_def_opts(gensym(),opts,name,params...) :
+    name isa Expr ? ode_def_opts(gensym(),opts,name,ex,params...) :
         ode_def_opts(name,opts,ex,params...)
 end
 
@@ -64,6 +64,6 @@ macro ode_def_noinvjac(name,ex,params...)
     :build_hes => false,
     :build_invhes => false,
     :build_dpfuncs => true)
-    name isa Expr ? ode_def_opts(gensym(),opts,name,params...) :
+    name isa Expr ? ode_def_opts(gensym(),opts,name,ex,params...) :
         ode_def_opts(name,opts,ex,params...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,6 +114,12 @@ end a b c d
 
 @test DiffEqBase.__has_syms(f_t_noname)
 
+f = @ode_def begin
+  dx = a*x - b*x*y
+  dy = -c*y + d*x*y
+end a b c d
+@test_nowarn f([0.1,0.2], [1,2], [1,2,3,4], 1)
+
 println("Make the problems in the problem library build")
 
 using DiffEqProblemLibrary


### PR DESCRIPTION
This PR fixes the following error
```julia
julia> f = @ode_def begin
         dx = a*x - b*x*y
         dy = -c*y + d*x*y
       end a b c d
#375 (generic function with 2 methods)

julia> f([0.1,0.2], [1,2], [1,2,3,4], 1)
ERROR: UndefVarError: a not defined
Stacktrace:
 [1] macro expansion at ./REPL[19]:2 [inlined]
 [2] (::getfield(Main, Symbol("##213#219")))(::Array{Float64,1}, ::Array{Int64,1}, ::Array{Int64,1}, ::Int64) at /home/scheme/.julia/dev/ParameterizedFunctions/src/ode_def_opts.jl:235
 [3] (::getfield(Main, Symbol("##375")){getfield(Main, Symbol("##213#219")),getfield(Main, Symbol("##214#220")),getfield(Main, Symbol("##215#221")),getfield(Main, Symbol("##216#222")),getfield(Main, Symbol("##217#223")),getfield(Main, Symbol("##218#224")),Expr,Expr})(::Array{Float64,1}, ::Array{Int64,1}, ::Array{Int64,1}, ::Int64) at /home/scheme/.julia/dev/ParameterizedFunctions/src/maketype.jl:82
 [4] top-level scope at none:0
```