### PR TITLE
Use ModelingToolkit.t_nounits to fix independent variable warning

### DIFF
--- a/src/ode_def_opts.jl
+++ b/src/ode_def_opts.jl
@@ -56,7 +56,7 @@ function ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, 
     indvar_dict, syms = build_indvar_dict(ex, depvar)
     ####
 
-    t = Symbolics.unwrap((@variables t)[1])
+    t = ModelingToolkit.t_nounits
     vars = Symbolics.unwrap.([(@variables $x(t))[1] for x in syms])
     params = Symbolics.unwrap.([(@parameters $x)[1] for x in Symbol[params...]])
 


### PR DESCRIPTION
## Summary
- Replaces `@variables t` with `ModelingToolkit.t_nounits` in `ode_def_opts.jl`
- This eliminates the warning "Independent variable t should be defined with @independent_variables t" when creating ODEs

Fixes #138

## Test plan
- [x] Verified the fix eliminates the warning using the example from the issue
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)