### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,13 +5,19 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
 include("pages.jl")
 
-makedocs(sitename = "ParameterizedFunctions.jl",
+makedocs(
+    sitename = "ParameterizedFunctions.jl",
     authors = "Chris Rackauckas",
     modules = [ParameterizedFunctions],
     clean = true, doctest = false, linkcheck = true,
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/ParameterizedFunctions/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/ParameterizedFunctions/stable/"
+    ),
+    pages = pages
+)
 
-deploydocs(repo = "github.com/SciML/ParameterizedFunctions.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/ParameterizedFunctions.jl.git";
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -2,5 +2,5 @@
 
 pages = [
     "Home" => "index.md",
-    "The ode_def Macro" => "ode_def.md"
+    "The ode_def Macro" => "ode_def.md",
 ]

--- a/src/ParameterizedFunctions.jl
+++ b/src/ParameterizedFunctions.jl
@@ -5,27 +5,27 @@ $(DocStringExtensions.README)
 """
 module ParameterizedFunctions
 
-using DocStringExtensions: DocStringExtensions
-using DataStructures: DataStructures, OrderedDict
-using DiffEqBase: DiffEqBase
-using Latexify: Latexify, @latexrecipe, latexify
-using Reexport: @reexport
-@reexport using ModelingToolkit
-using ModelingToolkit: ModelingToolkit, System, tosymbol
-using ModelingToolkitBase: @parameters
-using Symbolics: Symbolics, @variables
-using SymbolicUtils: SymbolicUtils, BasicSymbolic
+    using DocStringExtensions: DocStringExtensions
+    using DataStructures: DataStructures, OrderedDict
+    using DiffEqBase: DiffEqBase
+    using Latexify: Latexify, @latexrecipe, latexify
+    using Reexport: @reexport
+    @reexport using ModelingToolkit
+    using ModelingToolkit: ModelingToolkit, System, tosymbol
+    using ModelingToolkitBase: @parameters
+    using Symbolics: Symbolics, @variables
+    using SymbolicUtils: SymbolicUtils, BasicSymbolic
 
-import LinearAlgebra
-import SciMLBase
+    import LinearAlgebra
+    import SciMLBase
 
-include("ode_def_opts.jl")
-include("utils.jl")
-include("dict_build.jl")
-include("macros.jl")
-include("latexify.jl")
+    include("ode_def_opts.jl")
+    include("utils.jl")
+    include("dict_build.jl")
+    include("macros.jl")
+    include("latexify.jl")
 
-export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
+    export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
 end # module
 
 ##### Extra

--- a/src/dict_build.jl
+++ b/src/dict_build.jl
@@ -18,7 +18,7 @@ function build_indvar_dict(ex, depvar)
         end
     end
     syms = indvar_dict.keys
-    indvar_dict, syms
+    return indvar_dict, syms
 end
 
 function build_param_list(params)
@@ -30,5 +30,5 @@ function build_param_list(params)
             warn("p=>val and p=val are deprecated. Simply list the parameters. See the DifferentialEquations.jl documentation for more information on the syntax change.")
         end
     end
-    param_dict
+    return param_dict
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -33,16 +33,18 @@ extra definitions (Jacobian, parameter Jacobian, etc.) defined through the MTK
 symbolic tools.
 """
 macro ode_def(name, ex, params...)
-    opts = Dict{Symbol, Bool}(:build_tgrad => true,
+    opts = Dict{Symbol, Bool}(
+        :build_tgrad => true,
         :build_jac => true,
         :build_expjac => false,
         :build_invjac => false,
         :build_invW => false,
         :build_hes => false,
         :build_invhes => false,
-        :build_dpfuncs => true)
-    name isa Expr ? ode_def_opts(gensym(), opts, __module__, name, ex, params...) :
-    ode_def_opts(name, opts, __module__, ex, params...)
+        :build_dpfuncs => true
+    )
+    return name isa Expr ? ode_def_opts(gensym(), opts, __module__, name, ex, params...) :
+        ode_def_opts(name, opts, __module__, ex, params...)
 end
 
 """
@@ -56,16 +58,18 @@ Like `@ode_def` but the `opts` options are set so that no symbolic functions are
 See the `@ode_def` docstring for more details.
 """
 macro ode_def_bare(name, ex, params...)
-    opts = Dict{Symbol, Bool}(:build_tgrad => false,
+    opts = Dict{Symbol, Bool}(
+        :build_tgrad => false,
         :build_jac => false,
         :build_expjac => false,
         :build_invjac => false,
         :build_invW => false,
         :build_hes => false,
         :build_invhes => false,
-        :build_dpfuncs => false)
-    name isa Expr ? ode_def_opts(gensym(), opts, __module__, name, ex, params...) :
-    ode_def_opts(name, opts, __module__, ex, params...)
+        :build_dpfuncs => false
+    )
+    return name isa Expr ? ode_def_opts(gensym(), opts, __module__, name, ex, params...) :
+        ode_def_opts(name, opts, __module__, ex, params...)
 end
 
 """
@@ -79,14 +83,16 @@ Like `@ode_def` but the `opts` options are set so that all possible symbolic fun
 See the `@ode_def` docstring for more details.
 """
 macro ode_def_all(name, ex, params...)
-    opts = Dict{Symbol, Bool}(:build_tgrad => true,
+    opts = Dict{Symbol, Bool}(
+        :build_tgrad => true,
         :build_jac => true,
         :build_expjac => false,
         :build_invjac => false,
         :build_invW => true,
         :build_hes => false,
         :build_invhes => false,
-        :build_dpfuncs => true)
-    name isa Expr ? ode_def_opts(gensym(), opts, __module__, name, ex, params...) :
-    ode_def_opts(name, opts, __module__, ex, params...)
+        :build_dpfuncs => true
+    )
+    return name isa Expr ? ode_def_opts(gensym(), opts, __module__, name, ex, params...) :
+        ode_def_opts(name, opts, __module__, ex, params...)
 end

--- a/src/ode_def_opts.jl
+++ b/src/ode_def_opts.jl
@@ -1,6 +1,6 @@
 findreplace(ex::Symbol, dict) = get(dict, ex, ex)
 function findreplace(ex::Expr, dict)
-    Expr(ex.head, map(x -> findreplace(x, dict), ex.args)...)
+    return Expr(ex.head, map(x -> findreplace(x, dict), ex.args)...)
 end
 findreplace(ex, dict) = ex
 
@@ -40,8 +40,10 @@ opts = Dict{Symbol, Bool}(:build_tgrad => true,
     :build_dpfuncs => true)
 ```
 """
-function ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, params...;
-        depvar = :t)
+function ode_def_opts(
+        name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, params...;
+        depvar = :t
+    )
     # depvar is the dependent variable. Defaults to t
     # M is the mass matrix in RosW, must be a constant!
 
@@ -161,9 +163,9 @@ function ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, 
         end
     end
 
-    quote
+    return quote
         struct $name{F, TG, TJ, TW, TWt, S} <:
-               ParameterizedFunctions.DiffEqBase.AbstractParameterizedFunction{true}
+            ParameterizedFunctions.DiffEqBase.AbstractParameterizedFunction{true}
             f::F
             mass_matrix::ParameterizedFunctions.LinearAlgebra.UniformScaling{Bool}
             analytic::Nothing
@@ -196,9 +198,11 @@ function ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, 
         $full_jex
         $full_wex
 
-        $name($fname, ParameterizedFunctions.LinearAlgebra.I, nothing, $tname, $jname,
+        $name(
+            $fname, ParameterizedFunctions.LinearAlgebra.I, nothing, $tname, $jname,
             nothing, nothing,
             nothing, nothing, $Wname, $W_tname, nothing, $syms, $(Meta.quot(depvar)),
-            nothing, $sys, nothing, nothing)
+            nothing, $sys, nothing, nothing
+        )
     end |> esc
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,14 +3,17 @@ function flip_mult!(ex)
     for (i, arg) in enumerate(ex.args)
         if isa(arg, Expr)
             if arg.args[1] == :(*) && length(arg.args) >= 3 &&
-               (isa(arg.args[2], Number) ||
-                (isa(arg.args[2], Expr) && arg.args[2].args[1] == :-))
+                    (
+                    isa(arg.args[2], Number) ||
+                        (isa(arg.args[2], Expr) && arg.args[2].args[1] == :-)
+                )
                 arg.args[3], arg.args[2] = arg.args[2], arg.args[3]
             else
                 flip_mult!(arg)
             end
         end
     end
+    return
 end
 
 function build_component_funcs(symex)
@@ -27,7 +30,7 @@ function build_component_funcs(symex)
             end
         end
     end
-    funcs
+    return funcs
 end
 
 function modelingtoolkitize_expr(ex::Expr, vars, curmod)
@@ -36,21 +39,21 @@ function modelingtoolkitize_expr(ex::Expr, vars, curmod)
     ex.head === :call ||
         throw(ArgumentError("internal representation does not support non-call Expr"))
     op = ex.args[1] ∈ names ? vars[findfirst(x -> ex.args[1] == tosymbol(x), vars)] :
-         getproperty(curmod, ex.args[1]) # HACK
+        getproperty(curmod, ex.args[1]) # HACK
     return op((modelingtoolkitize_expr(x, vars, curmod) for x in ex.args[2:end])...)
 end
 
 function modelingtoolkitize_expr(ex::BasicSymbolic, vars, curmod)
-    ex
+    return ex
 end
 
 function modelingtoolkitize_expr(ex::Symbol, vars, curmod)
     names = tosymbol.(vars)
     idx = findfirst(x -> ex == x, names)
     op = idx !== nothing ? vars[idx] : getproperty(curmod, ex)
-    op
+    return op
 end
 
 function modelingtoolkitize_expr(ex::Number, vars, curmod)
-    ex
+    return ex
 end

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -9,7 +9,9 @@ using Symbolics
     # Skip modules that are re-exported (names from @reexport using ModelingToolkit
     # are intentionally brought in implicitly for re-export purposes), and Base/Core
     # which are always available implicitly
-    @test check_no_implicit_imports(ParameterizedFunctions;
-        skip = (Base, Core, ModelingToolkit, ModelingToolkitBase, Symbolics)) === nothing
+    @test check_no_implicit_imports(
+        ParameterizedFunctions;
+        skip = (Base, Core, ModelingToolkit, ModelingToolkitBase, Symbolics)
+    ) === nothing
     @test check_no_stale_explicit_imports(ParameterizedFunctions) === nothing
 end

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -3,8 +3,10 @@ using ParameterizedFunctions, Aqua
     Aqua.find_persistent_tasks_deps(ParameterizedFunctions)
     Aqua.test_ambiguities(ParameterizedFunctions, recursive = false)
     Aqua.test_deps_compat(ParameterizedFunctions)
-    Aqua.test_piracies(ParameterizedFunctions,
-        treat_as_own = [ParameterizedFunctions.SciMLBase.AbstractParameterizedFunction])
+    Aqua.test_piracies(
+        ParameterizedFunctions,
+        treat_as_own = [ParameterizedFunctions.SciMLBase.AbstractParameterizedFunction]
+    )
     Aqua.test_project_extras(ParameterizedFunctions)
     Aqua.test_stale_deps(ParameterizedFunctions)
     Aqua.test_unbound_args(ParameterizedFunctions)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,8 +61,10 @@ f_t.tgrad(grad, u, p, t)
 
 println("Test Jacobians")
 f.jac(J, u, p, t)
-@test J == [-1.5 -2.0
-            3.0 -1.0]
+@test J == [
+    -1.5 -2.0
+    3.0 -1.0
+]
 @test f.jac(u, p, t) == [-1.5 -2.0; 3.0 -1.0]
 
 @code_llvm SciMLBase.has_jac(f)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)