### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/ParameterizedFunctions.jl
+++ b/src/ParameterizedFunctions.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 """
 $(DocStringExtensions.README)
 """
@@ -27,66 +25,3 @@ module ParameterizedFunctions
 
     export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
 end # module
-
-##### Extra
-
-# Jacobian Factorization
-
-#=
-local fsymjac_L
-local fsymjac_U
-local Jex_L
-local Jex_U
-try
-  # Factorize the Jacobian
-  fsymjac = lufact(symjac)
-  fsymjac_L = fsymjac[:L]
-  fsymjac_U = fsymjac[:U]
-  Jex_L,Jex_U = build_fjac_func(fsymjac_L,fsymjac_U,indvar_dict,param_dict,inline_dict)
-catch
-  fsymjac_L = Matrix{SymEngine.Basic}(0,0)
-  fsymjac_U = Matrix{SymEngine.Basic}(0,0)
-end
-
-"""
-Builds the LU-factorized Jacobian functions
-"""
-function build_fjac_func(symjac_L,symjac_U,indvar_dict,param_dict,inline_dict)
-  # Lower Triangle
-  Jex = :()
-  for i in 1:size(symjac_L,1)
-    for j in 1:i
-      ex = parse(string(symjac_L[i,j]))
-      if ex isa Expr
-        ode_findreplace(ex,ex,indvar_dict,param_dict,inline_dict)
-      else
-        ex = ode_symbol_findreplace(ex,indvar_dict,param_dict,inline_dict)
-      end
-      push!(Jex.args,:(J[$i,$j] = $ex))
-    end
-  end
-  Jex.head = :block
-  push!(Jex.args,nothing)
-  Jex_L = :(jac = (t,u,J)->$Jex)
-
-  # Upper Triangle
-  Jex = :()
-  for j in 1:size(symjac_U,2)
-    for i in 1:j
-      ex = parse(string(symjac_U[i,j]))
-      if ex isa Expr
-        ode_findreplace(ex,ex,indvar_dict,param_dict,inline_dict)
-      else
-        ex = ode_symbol_findreplace(ex,indvar_dict,param_dict,inline_dict)
-      end
-      push!(Jex.args,:(J[$i,$j] = $ex))
-    end
-  end
-  Jex.head = :block
-  push!(Jex.args,nothing)
-  Jex_U = :(jac = (t,u,J)->$Jex)
-
-  Jex_L,Jex_U
-end
-
-=#

--- a/src/dict_build.jl
+++ b/src/dict_build.jl
@@ -7,7 +7,7 @@ function build_indvar_dict(ex, depvar)
         if firstarg == :d
             nodarg = Symbol(join(Base.Iterators.drop(string(arg), 1)))
             if nodarg == depvar
-                warn("$depvar is fixed as the independent variable but is also used as a dependent variable. Results my be incorrect.")
+                @warn "$depvar is fixed as the independent variable but is also used as a dependent variable. Results may be incorrect."
             end
             if !haskey(indvar_dict, nodarg)
                 cur_sym += 1
@@ -27,8 +27,8 @@ function build_param_list(params)
         if params[i] isa Symbol
             push!(param_list, params[i])
         elseif params[i].head == :call || params[i].head == :(=)
-            warn("p=>val and p=val are deprecated. Simply list the parameters. See the DifferentialEquations.jl documentation for more information on the syntax change.")
+            @warn "p=>val and p=val are deprecated. Simply list the parameters. See the DifferentialEquations.jl documentation for more information on the syntax change."
         end
     end
-    return param_dict
+    return param_list
 end


### PR DESCRIPTION
## Summary

- Remove `__precompile__()` call (no-op since Julia 1.8, modules precompile by default)
- Replace removed `warn()` function calls with `@warn` macro in `dict_build.jl` (`warn` was removed from Base in Julia 1.0)
- Fix `build_param_list` returning undefined variable `param_dict` instead of `param_list`
- Fix typo "my be" → "may be" in warning message
- Remove commented-out dead code using deprecated `lufact()` API (old Jacobian LU factorization code that used SymEngine.Basic)

## Details

While no deprecation warnings are currently emitted at runtime (tests pass with `--depwarn=error`), the codebase contained usage of APIs that have been removed from Julia:

1. **`warn()` function** (removed in Julia 1.0, replaced by `@warn` macro): Used in `build_indvar_dict` and `build_param_list` in `dict_build.jl`. These code paths would cause `UndefVarError` if reached.

2. **`__precompile__()`**: Deprecated since Julia 1.8. All modules precompile by default now.

3. **`build_param_list` bug**: The function returned `param_dict` (undefined) instead of `param_list`. This function is currently unused but was broken.

4. **Commented-out code with `lufact()`**: Dead code from the SymEngine era using `lufact()` (renamed to `lu` in Julia 1.0) and `Matrix{SymEngine.Basic}`.

## Upstream dependencies note

No upstream dependency changes needed. All current MTK v11 APIs used (`tosymbol`, `generate_rhs`, `generate_tgrad`, `generate_jacobian`, `generate_factorized_W`, `System`) work without deprecation warnings.

The `test_undefined_exports` Aqua test remains `broken = true` due to MTK v11 exporting `Variable` and `find_solvables!` which are undefined — this is an upstream MTK issue.

## Test plan

- [x] Tests pass with `julia --depwarn=error` (direct invocation)
- [x] Tests pass with `Pkg.test()`
- [x] Runic formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)