### PR TITLE
Bump DiffEqBase compat to include v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParameterizedFunctions"
 uuid = "65888b18-ceab-5e60-b2b9-181511a3b968"
-version = "5.23.0"
+version = "5.24.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
@@ -19,7 +19,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 [compat]
 Aqua = "0.8"
 DataStructures = "0.18.13, 0.19"
-DiffEqBase = "6.144"
+DiffEqBase = "6.144, 7"
 DocStringExtensions = "0.9"
 ExplicitImports = "1.14.0"
 InteractiveUtils = "1.10"


### PR DESCRIPTION
## Summary

Widen `DiffEqBase = "6.144"` → `"6.144, 7"` so ParameterizedFunctions resolves alongside `lib/DiffEqBase` 7.0.0 (shipping with OrdinaryDiffEq v7). Bumps 5.23.0 → 5.24.0.

`SciMLBase = "2.15, 3.0"` already covers v3. `ModelingToolkit = "11"` covers the MTK 11.22.0 compat-widened release in flight (SciML/ModelingToolkit.jl#4467).

## Why this is source-level safe

`src/` uses only `DiffEqBase.AbstractParameterizedFunction` from DiffEqBase; that symbol is still defined in `lib/DiffEqBase` v7 via the `@static if isdefined(SciMLBase, :AbstractParameterizedFunction)` delegation/fallback block.

Grepped `src/` for every symbol removed in the v7 NEWS / SciMLBase v3 breaking notes: `u_modified!`, `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`, `intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution` — zero matches.

## Scope

Not a direct blocker of OrdinaryDiffEq.jl#3488's own test matrix — ParameterizedFunctions is a test-only `[extras]` dep of DiffEqDevTools (not a runtime `[deps]`), so OrdinaryDiffEq tests don't pull it in. Included in the same compat-widening set as DiffEqCallbacks#303, DiffEqNoiseProcess#271, DiffEqProblemLibrary#182, JumpProcesses#580, ModelingToolkit#4467, StateSelection#71 so downstream users can install ParameterizedFunctions with the v7 stack once it's registered.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>