### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,25 +13,11 @@ on:
 jobs:
   test:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group:
-          - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: "Core"
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.16.23 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/src/ParameterizedFunctions.jl
+++ b/src/ParameterizedFunctions.jl
@@ -3,25 +3,25 @@ $(DocStringExtensions.README)
 """
 module ParameterizedFunctions
 
-    using DocStringExtensions: DocStringExtensions
-    using DataStructures: DataStructures, OrderedDict
-    using DiffEqBase: DiffEqBase
-    using Latexify: Latexify, @latexrecipe, latexify
-    using Reexport: @reexport
-    @reexport using ModelingToolkit
-    using ModelingToolkit: ModelingToolkit, System, tosymbol
-    using ModelingToolkitBase: @parameters
-    using Symbolics: Symbolics, @variables
-    using SymbolicUtils: SymbolicUtils, BasicSymbolic
+using DocStringExtensions: DocStringExtensions
+using DataStructures: DataStructures, OrderedDict
+using DiffEqBase: DiffEqBase
+using Latexify: Latexify, @latexrecipe, latexify
+using Reexport: @reexport
+@reexport using ModelingToolkit
+using ModelingToolkit: ModelingToolkit, System, tosymbol
+using ModelingToolkitBase: @parameters
+using Symbolics: Symbolics, @variables
+using SymbolicUtils: SymbolicUtils, BasicSymbolic
 
-    import LinearAlgebra
-    import SciMLBase
+import LinearAlgebra
+import SciMLBase
 
-    include("ode_def_opts.jl")
-    include("utils.jl")
-    include("dict_build.jl")
-    include("macros.jl")
-    include("latexify.jl")
+include("ode_def_opts.jl")
+include("utils.jl")
+include("dict_build.jl")
+include("macros.jl")
+include("latexify.jl")
 
-    export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
+export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
 end # module


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI to the centralized SciML reusable workflows (all pinned `@v1`, every caller gets `secrets: "inherit"`). End-state mirrors Sundials.jl.

## Converted (inline -> central caller)
- **FormatCheck.yml (Runic)**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline -> `downgrade.yml@v1`, preserving `if: false`, `group: Core`, `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`

## Already central (unchanged)
- **Tests.yml** -> `tests.yml@v1` (version x os matrix preserved; carries `secrets: "inherit"`)
- **Documentation.yml** -> `documentation.yml@v1` (carries `secrets: "inherit"`)

## Added
- None (no Downstream/Benchmark/CompatHelper present; Tests/Docs/Runic/SpellCheck/Downgrade all now central).

## Formatting / spelling
- **Runic**: applied formatting to `src/ParameterizedFunctions.jl` (module-level indentation removed). The previous inline Runic check was not actually clean.
- **typos**: 0 fixes needed — `typos .` already exits 0 thanks to the existing `.typos.toml`.

## Cleanup
- **dependabot.yml**: removed the obsolete `crate-ci/typos` version-ignore (now centralized); dropped the `/test` entry from the julia ecosystem block since there is no `test/Project.toml`. `github-actions` (weekly, `/`) and `julia` (daily, `/` + `/docs`, group `all-julia-packages: ["*"]`) preserved.
- No `CompatHelper.yml` present. `TagBot.yml` left unchanged.

## Heads up
- Check **names change** (jobs now run as reusable callers). Branch-protection required checks may need updating accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)