### PR TITLE
Bump version to 5.24.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParameterizedFunctions"
 uuid = "65888b18-ceab-5e60-b2b9-181511a3b968"
-version = "5.24.1"
+version = "5.24.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (5.24.1 -> 5.24.2) to release unreleased commits on `master` via JuliaRegistrator.