### PR TITLE
Release prep: bump ParameterizedFunctions to 5.24.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParameterizedFunctions"
 uuid = "65888b18-ceab-5e60-b2b9-181511a3b968"
-version = "5.24.2"
+version = "5.24.3"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release to register the accumulated docstring/QA/test-scaffolding changes (incl. SciMLTesting test-dep compat bump) since 5.24.2. Version-only change.