### PR TITLE
Enforce strict QA for ParameterizedFunctions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,15 @@
 name = "ParameterizedFunctions"
 uuid = "65888b18-ceab-5e60-b2b9-181511a3b968"
-version = "5.24.3"
+version = "6.0.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 ModelingToolkitBase = "7771a370-6774-4173-bd38-47e70ca0b839"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
@@ -25,10 +23,9 @@ Latexify = "0.16"
 LinearAlgebra = "1.10"
 ModelingToolkit = "11.26.7"
 ModelingToolkitBase = "1.42.0"
-Reexport = "1.2.2"
 SafeTestsets = "0.0.1, 0.1"
 SciMLBase = "2.149.0, 3.0"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 SpecialFunctions = "2"
 Symbolics = "7.24.0"
 SymbolicUtils = "4.31.0"
@@ -40,7 +37,8 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "SafeTestsets", "SciMLTesting", "SpecialFunctions", "Test"]
+test = ["InteractiveUtils", "Latexify", "SafeTestsets", "SciMLTesting", "SpecialFunctions", "Test"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 
 [compat]
 Documenter = "1"
-ParameterizedFunctions = "5"
+Latexify = "0.16"
+ParameterizedFunctions = "6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ makedocs(
     sitename = "ParameterizedFunctions.jl",
     authors = "Chris Rackauckas",
     modules = [ParameterizedFunctions],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, doctest = true, checkdocs = :exports, linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/ParameterizedFunctions/stable/"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -3,4 +3,5 @@
 pages = [
     "Home" => "index.md",
     "The ode_def Macro" => "ode_def.md",
+    "Developer API" => "developer_api.md",
 ]

--- a/docs/src/developer_api.md
+++ b/docs/src/developer_api.md
@@ -1,0 +1,12 @@
+# Developer API
+
+`ode_def_opts` is the low-level implementation used by the public `@ode_def`,
+`@ode_def_bare`, and `@ode_def_all` macros. It is exported for compatibility,
+but package users should use those macros. It is intended for SciML package
+developers that need to define a macro with a different set of generated
+derivative functions; its input expression must follow the assignment-based
+ODE DSL accepted by `@ode_def`.
+
+```@docs
+ParameterizedFunctions.ode_def_opts
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,6 +3,10 @@
 ParameterizedFunctions.jl is a component of the SciML ecosystem which allows
 for easily defining parameterized ODE models in a simple syntax.
 
+```@docs
+ParameterizedFunctions.ParameterizedFunctions
+```
+
 ## Installation
 
 To install ParameterizedFunctions.jl, use the Julia package manager:
@@ -69,7 +73,7 @@ L"\begin{align}
 ## Contributing
 
   - Please refer to the
-    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
+    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac)
     for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.

--- a/docs/src/ode_def.md
+++ b/docs/src/ode_def.md
@@ -6,9 +6,12 @@ ParameterizedFunctions.@ode_def_bare
 ParameterizedFunctions.@ode_def_all
 ```
 
-## Internal API
+```@example ode_def
+using ParameterizedFunctions
 
-```@docs
-ParameterizedFunctions.ode_def_opts
-ParameterizedFunctions.ParameterizedFunctions
+linear = @ode_def begin
+    dx = a * x
+end a
+
+linear([2.0], [3.0], 0.0)
 ```

--- a/src/ParameterizedFunctions.jl
+++ b/src/ParameterizedFunctions.jl
@@ -6,9 +6,6 @@ module ParameterizedFunctions
 using DocStringExtensions: DocStringExtensions
 using DataStructures: DataStructures, OrderedDict
 using DiffEqBase: DiffEqBase
-using Latexify: Latexify, @latexrecipe, latexify
-using Reexport: @reexport
-@reexport using ModelingToolkit
 using ModelingToolkit: ModelingToolkit, System, tosymbol
 using ModelingToolkitBase: ModelingToolkitBase, @parameters
 using Symbolics: Symbolics, @variables
@@ -21,7 +18,6 @@ include("ode_def_opts.jl")
 include("utils.jl")
 include("dict_build.jl")
 include("macros.jl")
-include("latexify.jl")
 
 export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
 end # module

--- a/src/latexify.jl
+++ b/src/latexify.jl
@@ -1,3 +1,0 @@
-@latexrecipe function f(func::SciMLBase.AbstractParameterizedFunction)
-    return latexify(func.sys)
-end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,36 +1,41 @@
 """
-```
-@ode_def name begin
-    differential equation
-end parameters :: ODEFunction
-```
+    @ode_def [name] begin
+        dstate = expression
+        # additional derivative assignments
+    end parameter_names...
 
-## Definition of the Domain-Specific Language (DSL)
+Define a parameterized ordinary differential equation and return an
+`SciMLBase.AbstractParameterizedFunction` suitable for an `ODEProblem`. The macro
+generates in-place and out-of-place right-hand sides, a time gradient, and a
+Jacobian through ModelingToolkit.
 
-A helper macro is provided to make it easier to define a `ParameterizedFunction`,
-and it will symbolically compute a bunch of extra functions to make the differential
-equation solvers run faster. For example, to define the previous `LotkaVolterra`,
-you can use the following command:
+# Arguments
+
+- `name`: optional name for the generated function type. Omit it to return an
+  anonymous parameterized function.
+- derivative assignments: a `begin` block whose statements have the form
+  `dstate = expression`. The identifier after `d` becomes a state variable. The
+  independent variable is `t`.
+- `parameter_names...`: symbols used as parameters in the derivative expressions.
+  Their numerical values are supplied by the problem's `p` argument.
+
+# Keywords
+
+This macro does not accept keyword arguments.
+
+# Returns
+
+An `AbstractParameterizedFunction` with generated `f`, `tgrad`, and `jac`
+methods. Pass it as the `f` argument of an `ODEProblem`.
+
+# Examples
 
 ```julia
-f = @ode_def LotkaVolterra begin
+lotka_volterra = @ode_def begin
     dx = a * x - b * x * y
     dy = -c * y + d * x * y
 end a b c d
 ```
-
-or you can define it anonymously:
-
-```julia
-f = @ode_def begin
-    dx = a * x - b * x * y
-    dy = -c * y + d * x * y
-end a b c d
-```
-
-`@ode_def` uses ModelingToolkit.jl internally and returns an `ODEFunction` with the
-extra definitions (Jacobian, parameter Jacobian, etc.) defined through the MTK
-symbolic tools.
 """
 macro ode_def(name, ex, params...)
     opts = Dict{Symbol, Bool}(
@@ -48,14 +53,37 @@ macro ode_def(name, ex, params...)
 end
 
 """
-```
-@ode_def_bare name begin
-    differential equation
-end parameters :: ODEFunction
-```
+    @ode_def_bare [name] begin
+        dstate = expression
+        # additional derivative assignments
+    end parameter_names...
 
-Like `@ode_def` but the `opts` options are set so that no symbolic functions are generated.
-See the `@ode_def` docstring for more details.
+Define a parameterized ODE without generating symbolic derivative functions.
+
+# Arguments
+
+- `name`: optional name for the generated function type.
+- derivative assignments: the same assignment-based ODE DSL accepted by
+  `@ode_def`.
+- `parameter_names...`: symbols used as parameters in the expressions.
+
+# Keywords
+
+This macro does not accept keyword arguments.
+
+# Returns
+
+An `AbstractParameterizedFunction` with a generated right-hand side and `nothing`
+for generated derivative-function fields. Use it when symbolic Jacobian and time
+gradient generation is unnecessary.
+
+# Examples
+
+```julia
+linear = @ode_def_bare begin
+    dx = a * x
+end a
+```
 """
 macro ode_def_bare(name, ex, params...)
     opts = Dict{Symbol, Bool}(
@@ -73,14 +101,37 @@ macro ode_def_bare(name, ex, params...)
 end
 
 """
-```
-@ode_def_all name begin
-    differential equation
-end parameters :: ODEFunction
-```
+    @ode_def_all [name] begin
+        dstate = expression
+        # additional derivative assignments
+    end parameter_names...
 
-Like `@ode_def` but the `opts` options are set so that all possible symbolic functions are generated.
-See the `@ode_def` docstring for more details.
+Define a parameterized ODE and request every derivative function supported by this
+DSL, including factorized `W` functions for small systems.
+
+# Arguments
+
+- `name`: optional name for the generated function type.
+- derivative assignments: the same assignment-based ODE DSL accepted by
+  `@ode_def`.
+- `parameter_names...`: symbols used as parameters in the expressions.
+
+# Keywords
+
+This macro does not accept keyword arguments.
+
+# Returns
+
+An `AbstractParameterizedFunction` with generated right-hand side, time-gradient,
+Jacobian, and supported factorized-`W` functions.
+
+# Examples
+
+```julia
+linear = @ode_def_all begin
+    dx = a * x
+end a
+```
 """
 macro ode_def_all(name, ex, params...)
     opts = Dict{Symbol, Bool}(

--- a/src/ode_def_opts.jl
+++ b/src/ode_def_opts.jl
@@ -5,39 +5,46 @@ end
 findreplace(ex, dict) = ex
 
 """
+    ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod,
+        ex::Expr, params...; depvar = :t)
+
+Build the expression emitted by the `@ode_def` family of macros.
+
+This is a developer API for packages that implement an ODE-definition macro. Most
+users should call `@ode_def`, `@ode_def_bare`, or `@ode_def_all` instead. Callers
+must pass the assignment-based DSL expression accepted by those macros; this
+function returns an expression and does not evaluate the generated definition.
+
+# Arguments
+
+- `name`: name of the generated `AbstractParameterizedFunction` subtype.
+- `opts`: derivative-generation options. `:build_tgrad`, `:build_jac`, and
+  `:build_invW` control generated functions. The compatibility keys
+  `:build_expjac`, `:build_invjac`, `:build_invW_t`, `:build_hes`,
+  `:build_invhes`, and `:build_dpfuncs` must also be present and have `Bool`
+  values, but do not currently change the generated expression.
+- `curmod`: module in which functions named in `ex` are resolved.
+- `ex`: `begin` expression containing `dstate = expression` assignments.
+- `params...`: parameter symbols used in `ex`.
+
+# Keywords
+
+- `depvar = :t`: symbol used for the independent variable. It must not also name a
+  dependent state.
+
+# Returns
+
+An expression that defines a concrete `AbstractParameterizedFunction` subtype,
+generated callable methods, and a singleton instance.
+
+# Examples
+
 ```julia
-ode_def_opts(name::Symbol, opts::Dict{Symbol, Bool}, curmod, ex::Expr, params...;
-    depvar = :t)
-```
-
-The core internal. Users should only interact with this through the `@ode_def_*` macros.
-
-Options are self-explanatory by name mapping to `ODEFunction`:
-
-  - build_tgrad
-  - build_jac
-  - build_expjac
-  - build_invjac
-  - build_invW
-  - build_invW_t
-  - build_hes
-  - build_invhes
-  - build_dpfuncs
-
-`depvar` sets the symbol for the dependent variable.
-
-Example:
-
-```julia
-opts = Dict{Symbol, Bool}(:build_tgrad => true,
-    :build_jac => true,
-    :build_expjac => false,
-    :build_invjac => true,
-    :build_invW => true,
-    :build_invW_t => true,
-    :build_hes => false,
-    :build_invhes => false,
-    :build_dpfuncs => true)
+opts = Dict{Symbol, Bool}(
+    :build_tgrad => true, :build_jac => true, :build_expjac => false,
+    :build_invjac => false, :build_invW => false, :build_invW_t => false,
+    :build_hes => false, :build_invhes => false, :build_dpfuncs => true,
+)
 ```
 """
 function ode_def_opts(

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1.10"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,26 +1,3 @@
-using SciMLTesting, ParameterizedFunctions, Test
+using SciMLTesting, ParameterizedFunctions
 
-dependency_reexports(pkg) = Tuple(
-    name for name in public_api_names(pkg)
-        if isdefined(pkg, name) && parentmodule(getfield(pkg, name)) !== pkg
-)
-
-const DEPENDENCY_REEXPORTS = dependency_reexports(ParameterizedFunctions)
-
-run_qa(
-    ParameterizedFunctions;
-    explicit_imports = true,
-    api_docs_kwargs = (;
-        rendered = true,
-        ignore = DEPENDENCY_REEXPORTS,
-        rendered_ignore = DEPENDENCY_REEXPORTS,
-    ),
-    aqua_kwargs = (;
-        piracies = (;
-            treat_as_own = [ParameterizedFunctions.SciMLBase.AbstractParameterizedFunction],
-        ),
-    ),
-    # MTK v11 has undefined exports (Variable, find_solvables!) that get re-exported.
-    # This is an upstream bug in ModelingToolkit, not ParameterizedFunctions.
-    aqua_broken = (:undefined_exports,),
-)
+run_qa(ParameterizedFunctions)


### PR DESCRIPTION
## Summary
- upgrade QA to SciMLTesting 2.4 with default strict checks
- remove dependency reexports and foreign Latexify piracy
- document public and developer APIs at their definitions

## Verification
- `Pkg.test()` passed: 17/17
- strict QA passed: 20/20
- Documenter doctests, `checkdocs = :exports`, and link checks passed
- Runic and `git diff --check` passed

Ignore until reviewed by @ChrisRackauckas.