### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParameterizedFunctions"
 uuid = "65888b18-ceab-5e60-b2b9-181511a3b968"
-version = "5.25.0"
+version = "5.26.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `master` can be registered in the General registry.

- ParameterizedFunctions: 5.25.0 -> 5.26.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
