### PR TITLE
Restore the documented ModelingToolkit surface as explicit exports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "5.26.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -16,6 +17,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [compat]
+CommonSolve = "0.2.4"
 DataStructures = "0.19"
 DiffEqBase = "7"
 DocStringExtensions = "0.9.5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ ParameterizedFunctions = "65888b18-ceab-5e60-b2b9-181511a3b968"
 [compat]
 Documenter = "1"
 Latexify = "0.16"
-ParameterizedFunctions = "6"
+ParameterizedFunctions = "5"

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -3,5 +3,6 @@
 pages = [
     "Home" => "index.md",
     "The ode_def Macro" => "ode_def.md",
+    "API" => "api.md",
     "Developer API" => "developer_api.md",
 ]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,48 @@
+# API
+
+The public API of ParameterizedFunctions is the `@ode_def` family of macros,
+documented on [The ode_def macro](@ref) page. `using ParameterizedFunctions` also
+reexports a small part of the ModelingToolkit interface, described below.
+
+## Reexported ModelingToolkit interface
+
+`@ode_def` is a front end for [ModelingToolkit](https://docs.sciml.ai/ModelingToolkit/stable/):
+it builds a `System` from the ODE DSL, keeps it in the generated function's `sys`
+field, and returns a function whose documented use is to be handed to an
+`ODEProblem` and solved. `using ParameterizedFunctions` brings the names that
+workflow touches into scope, so they do not have to be imported separately:
+
+```julia
+using ParameterizedFunctions
+
+lotka_volterra = @ode_def begin
+    dx = a * x - b * x * y
+    dy = -c * y + d * x * y
+end a b c d
+
+prob = ODEProblem(lotka_volterra, [1.0, 1.0], (0.0, 10.0), [1.5, 1.0, 3.0, 1.0])
+equations(lotka_volterra.sys)
+```
+
+ParameterizedFunctions only reexports these names — they are owned and documented
+upstream, at the links below.
+
+  - Using the result of `@ode_def`, owned by
+    [SciMLBase](https://docs.sciml.ai/SciMLBase/stable/) and
+    [CommonSolve](https://github.com/SciML/CommonSolve.jl): `ODEProblem`,
+    `ODEFunction`, `solve`
+  - The generated system and its accessors, owned by
+    [ModelingToolkitBase](https://docs.sciml.ai/ModelingToolkit/stable/) (the
+    type of the `sys` field): `System`, `equations`, `unknowns`, `parameters`,
+    `observed`, `independent_variable`, `mtkcompile`
+  - Symbolic variables, for building expressions to use with that system, owned by
+    [Symbolics](https://docs.sciml.ai/Symbolics/stable/) and ModelingToolkitBase:
+    `@variables`, `@parameters`, `Differential`, `Num`
+
+Anything else from ModelingToolkit, Symbolics or SciMLBase must be imported from
+those packages directly. In particular, ParameterizedFunctions does not reexport
+solver algorithms — `solve(prob, Tsit5())` still needs
+[OrdinaryDiffEq](https://docs.sciml.ai/DiffEqDocs/stable/) (or
+DifferentialEquations) — nor the acausal component-modelling surface of
+ModelingToolkit (`@mtkmodel`, `@named`, connectors, and the rest), which the
+`@ode_def` DSL does not use.

--- a/src/ParameterizedFunctions.jl
+++ b/src/ParameterizedFunctions.jl
@@ -15,12 +15,38 @@ using SymbolicUtils: SymbolicUtils, BasicSymbolic
 import LinearAlgebra
 import SciMLBase
 
+# ---------------------------------------------------------------------------
+# Reexported interface (see the second `export` block below).
+#
+# `@ode_def` is a front end for ModelingToolkit: it builds a `System`, keeps it in
+# the generated function's `sys` field, and returns something whose documented use
+# is `ODEProblem(f, u0, tspan, p); solve(prob, alg)`. Those names reached the user
+# through `@reexport using ModelingToolkit`, so `using ParameterizedFunctions` was
+# enough to write the documented workflow and to inspect `f.sys`.
+#
+# The blanket reexport (520 names) is gone; this is the subset that normal
+# documented use needs. Each name is imported from the module that owns it and
+# stays documented there.
+# ---------------------------------------------------------------------------
+using CommonSolve: solve
+using SciMLBase: ODEFunction, ODEProblem
+using ModelingToolkitBase: equations, independent_variable, mtkcompile, observed,
+    parameters, unknowns
+using Symbolics: Differential, Num
+
 include("ode_def_opts.jl")
 include("utils.jl")
 include("dict_build.jl")
 include("macros.jl")
 
 export @ode_def, ode_def_opts, @ode_def_bare, @ode_def_all
+
+# Reexported ModelingToolkit interface; approved via `reexports_allow` in
+# test/qa/qa.jl and documented in docs/src/api.md.
+export ODEFunction, ODEProblem, solve
+export System, equations, independent_variable, mtkcompile, observed, parameters,
+    unknowns
+export @parameters, @variables, Differential, Num
 
 @setup_workload begin
     @compile_workload begin

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,31 @@
-using SciMLTesting, ParameterizedFunctions
+using SciMLTesting, ParameterizedFunctions, Test
 
-run_qa(ParameterizedFunctions)
+# The ModelingToolkit interface ParameterizedFunctions deliberately reexports so that
+# `using ParameterizedFunctions` on its own is enough to write the documented workflow
+# -- define a model with `@ode_def`, hand it to `ODEProblem`, `solve` it, and inspect
+# the generated `System` in the `sys` field. Owned and documented upstream; kept in
+# sync with the reexport `export` block in src/ParameterizedFunctions.jl and the
+# "Reexported ModelingToolkit interface" section of docs/src/api.md.
+const REEXPORTS = (
+    # Using the result of `@ode_def`.
+    :ODEFunction, :ODEProblem, :solve,
+    # The `System` in the generated function's `sys` field, and its accessors.
+    :System, :equations, :independent_variable, :mtkcompile, :observed, :parameters,
+    :unknowns,
+    # Symbolic variables, for working with that system.
+    Symbol("@parameters"), Symbol("@variables"), :Differential, :Num,
+)
+
+run_qa(ParameterizedFunctions; reexports_allow = REEXPORTS)
+
+@testset "Reexport surface" begin
+    # Every approved reexport must actually be reachable from `using
+    # ParameterizedFunctions`, so the allow-list cannot drift into approving names the
+    # package no longer provides. `isdefined(@__MODULE__, ...)` tests the property
+    # directly: this file's `using ParameterizedFunctions` is what has to bring the
+    # name into scope.
+    @testset "$name" for name in REEXPORTS
+        @test name in names(ParameterizedFunctions)
+        @test isdefined(@__MODULE__, name)
+    end
+end


### PR DESCRIPTION
## What broke

`Enforce strict QA for ParameterizedFunctions (#171)` (8d598da) removed

```julia
@reexport using ModelingToolkit
```

and shipped it as a **minor** bump (5.24.3 → 5.25.0, after #172 walked the 6.0.0 back).

That reexport was ParameterizedFunctions' interface to its own output. `@ode_def` is a front end for ModelingToolkit: it builds a `System`, stores it in the generated function's `sys` field, and returns something whose documented use is `ODEProblem(f, u0, tspan, p)` followed by `solve`. On 5.25.0 `using ParameterizedFunctions` leaves **four** names in scope, all macros — so a user who followed the manual and then wanted `ODEProblem`, or `equations(f.sys)` after the Latex section, gets an `UndefVarError`. The test suite did not notice because `test/core.jl` already did `using DiffEqBase, SciMLBase` explicitly.

This is a fleet-wide pattern (NeuralPDE → NeuralLyapunov, JumpProcesses → MomentClosure, NBodySimulator).

## The fix

Follow SciML/Sundials.jl#553: not the blanket `@reexport using Dep`, and not a stripped surface — an explicit `export` list of exactly what normal documented use needs.

### How the list was chosen (evidence, not taste)

1. **README.md and docs/src/index.md** — the example is `prob = ODEProblem(lotka_volterra, u0, (0.0, 10.0), p)` then `sol = solve(prob, Tsit5(), ...)`; the Latex section is `latexify(lotka_volterra.sys)`, which is the documented entry point to the generated system.
2. **The `@ode_def` docstring** in `src/macros.jl` — *"Pass it as the `f` argument of an `ODEProblem`."*
3. **`src/ode_def_opts.jl`** — the generated struct's `sys::S` field holds the `System` built by `System(mtk_diffeqs, t, vars, params; ...)`, so the system accessors are what a reader of `.sys` reaches for next.

### What is restored (14 names, out of the 520 the blanket reexport provided)

| role | names | owner |
|---|---|---|
| Using the result of `@ode_def` | `ODEProblem`, `ODEFunction`, `solve` | SciMLBase, CommonSolve |
| The `System` in the `sys` field, and its accessors | `System`, `equations`, `unknowns`, `parameters`, `observed`, `independent_variable`, `mtkcompile` | ModelingToolkitBase |
| Symbolic variables for use with that system | `@variables`, `@parameters`, `Differential`, `Num` | Symbolics, ModelingToolkitBase |

**Deliberately not restored:** the acausal component-modelling surface (`@mtkmodel`, `@named`, connectors, hierarchical composition), which the `@ode_def` DSL does not use, and the rest of ModelingToolkit's 520-name export list. Solver algorithms are also not reexported — `solve(prob, Tsit5())` still needs OrdinaryDiffEq/DifferentialEquations, exactly as the README example shows.

Worth noting explicitly: `remake`, `init`, `ReturnCode` and `successful_retcode` are **not** in the list. ModelingToolkit does not export them, so they never came through this reexport — `test/core.jl`'s `remake` testset gets it from its own `using DiffEqBase`.

Each name is imported from the module that **owns** it — `ODEProblem`/`ODEFunction` from SciMLBase, `solve` from CommonSolve, the system accessors from ModelingToolkitBase, `Differential`/`Num` from Symbolics — so ExplicitImports' owner checks stay clean with no ignore-lists. CommonSolve becomes a direct dependency for this; it is a dependency-free 3-function package already deep in the graph.

## Documentation

New `docs/src/api.md`, wired into `docs/pages.jl`, with a **Reexported ModelingToolkit interface** section: the same names grouped by role, the upstream owner named and linked per group, a worked example, and an explicit boundary line — anything else from ModelingToolkit, Symbolics or SciMLBase must be imported from those packages directly, with the exclusions above called out and explained.

## Also here: a pre-existing docs-lane fix (not part of the reexport work)

`docs/Project.toml` pinned `ParameterizedFunctions = "6"`, anticipating a 6.0 that was never released — #171 bumped to 6.0.0 and #172 walked it back. The Documentation lane has therefore been unresolvable on master since then, independently of anything in this PR:

```
ERROR: empty intersection between ParameterizedFunctions@5.26.0 and project compatibility 6
```

The second commit pins it to `"5"`, the major the package actually is. **This is pre-existing breakage being cleared incidentally, not part of the reexport restoration** — it is included because that lane has to resolve before the new `docs/src/api.md` can be built at all. `docs/Project.toml` is the only place carrying the pin; `docs/src/assets/Project.toml` is generated by `docs/make.jl` at build time from it and is not committed.

## Drift protection

`test/qa/qa.jl` declares the same list through `reexports_allow` and adds a testset asserting every approved name is in `names(ParameterizedFunctions)` **and** actually in scope from `using ParameterizedFunctions`. The docs list, the `export` block and the `REEXPORTS` tuple are now the same list in three places.

## Semver

Restoring names that were exported through 5.24.3 is **not breaking**. No version bump in this PR; a separate release pass handles versions.

## Verification run locally (Julia 1.11.8, macOS aarch64)

- `run_qa(ParameterizedFunctions; reexports_allow = REEXPORTS)` — 20/20 pass; the new `Reexport surface` testset — 28/28 pass.
- `Pkg.test()` (Core group, `test/core.jl`) — 17/17 pass.
- The documented workflow from a bare `using ParameterizedFunctions`: `@ode_def` → `ODEProblem(lv, u0, tspan, p)` constructs; `lv.sys isa System` is true; `equations`, `unknowns`, `parameters`, `independent_variable` all resolve against it; `@parameters`, `@variables`, `Differential`, `Num` all in scope.

- Full `Documenter` build (`julia --project=docs docs/make.jl`) after the compat fix — succeeds clean: no errors and no warnings. `checkdocs = :exports` is satisfied with the 14 new reexported exports (Documenter does not require local docstrings for names owned by other modules), the `[The ode_def macro](@ref)` cross-reference from the new page resolves, doctests and `linkcheck` pass, and `docs/build/api/index.html` renders with the Reexported ModelingToolkit interface section. Nothing further was hiding behind the resolve failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
