### PR TITLE
Release ParameterizedFunctions 5.27.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParameterizedFunctions"
 uuid = "65888b18-ceab-5e60-b2b9-181511a3b968"
-version = "5.26.0"
+version = "5.27.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## What changed and why

Bumps ParameterizedFunctions from 5.26.0 to 5.27.0 to release the restored, explicitly documented ModelingToolkit surface from https://github.com/SciML/ParameterizedFunctions.jl/pull/177. This is the next consecutive version and follows the minor-bump policy for restored public API in a package at version 1 or later.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `QA/qa.jl | 48 passed / 48 total`; package tests passed.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `Core/core.jl | 17 passed / 17 total`; package tests passed.

## Not verified

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
